### PR TITLE
add responseObject getter

### DIFF
--- a/lib/REST/Client.pm
+++ b/lib/REST/Client.pm
@@ -448,6 +448,17 @@ sub responseHeader {
     return $self->{_res}->header($header);
 }
 
+=head3 responseObject
+
+Return a L<HTTP::Response> response object
+
+=cut
+
+sub responseObject {
+    my $self = shift;
+    return $self->{_res};
+}
+
 =head3 responseXpath ()
 
 A convienience wrapper that returns a L<XML::LibXML> xpath context for the body content.  Assumes the content is XML.

--- a/t/basic.t
+++ b/t/basic.t
@@ -3,6 +3,7 @@ use warnings;
 
 unshift @INC, "../lib";
 
+use Scalar::Util qw/blessed/;
 use Test::More;
 
 # Check testing prereqs
@@ -118,6 +119,8 @@ SKIP: {
 
         ok(scalar($client->responseHeaders()), 'Header names available');
         ok( $client->responseHeader('Client-Response-Num'), 'Can pull a header');
+
+        is( blessed($client->responseObject()), 'HTTP::Response', 'HTTP::Response available');
 
         my $fn = "content_file_test";
         $client->setContentFile( $fn );


### PR DESCRIPTION
Hello!

I suggest to add HTTP::Response object getter.
I want to make something like 

```
my $ro = $rest->POST($path, $data, $headers)->responseObject;
HTTP::Cookies->new()->extract_cookies($ro);
```

I can get HTTP::Response object through `$rest->{_res}`, but it seems a little bit ugly.

